### PR TITLE
Update for compatibility with nextflow on AWS

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,4 +1,4 @@
-
+nextflow.enable.dsl = 2
 def paramsWithUsage = readParamsFromJsonSettings()
 
 // Constants


### PR DESCRIPTION
Nextflow defining the DSL version has become required to AWS, with out it modules will not be imported and pipeline will fail. Should be default however specifically on AWS version of nextflow this is required to be explicit. 